### PR TITLE
infinate scroll as default

### DIFF
--- a/nitter.example.conf
+++ b/nitter.example.conf
@@ -43,4 +43,4 @@ replaceYouTube = ""
 replaceReddit = ""
 proxyVideos = true
 hlsPlayback = true
-infiniteScroll = false
+infiniteScroll = true


### PR DESCRIPTION
Infinite scroll because most people are likely to use Nitter on their local instance ….